### PR TITLE
add the property spring.autoconfigure.exclude to sender application.properties file

### DIFF
--- a/sender-app/configuration/application.properties
+++ b/sender-app/configuration/application.properties
@@ -62,6 +62,10 @@ logging.level.sender-complex-obs-sync=${openmrs.eip.log.level}
 # ****************************** Actuator Configuration ****************************************************************
 #
 #Whether to enable or disable all actuator endpoints by default.
+# if not excluded will get some errors at startup with missing class: META-INF/services/org/apache/activemq/transport/vm
+# Due to overlaps between activemq and artemis
+spring.autoconfigure.exclude=org.springframework.boot.actuate.autoconfigure.jms.JmsHealthContributorAutoConfiguration
+
 management.endpoints.enabled-by-default=false
 #management.endpoint.prometheus.enabled=true
 #management.endpoint.health.enabled=true


### PR DESCRIPTION
Have to exclude the autoconfiguration `org.springframework.boot.actuate.autoconfigure.jms.JmsHealthContributorAutoConfiguration` to avoid errors at startup due to missing class: `META-INF/services/org/apache/activemq/transport/vm`