### PR TITLE
EIP-129: Backport support for MySQL 8 for 3.0.x.

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,9 @@ defaults to `{eip.home}/logs/openmrs-eip.log`, where {eip.home} is the path to y
    the server-id needs to match the value of `debezium.db.serverId` property in the sender `application.properties` file.
 
    **DO NOT** set the `expire_logs_days` because you never want your logs to expire just in case the sync application is
-   run for a while due to unforeseen circumstances
+   run for a while due to unforeseen circumstances.
+
+    For MySQL 8 Support, more info are available on [openmrs-eip](https://github.com/openmrs/openmrs-eip#mysql-8-support)  
 
 2. #### Debezium user account
 

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ defaults to `{eip.home}/logs/openmrs-eip.log`, where {eip.home} is the path to y
    **DO NOT** set the `expire_logs_days` because you never want your logs to expire just in case the sync application is
    run for a while due to unforeseen circumstances.
 
-    For MySQL 8 Support, more info are available on [openmrs-eip](https://github.com/openmrs/openmrs-eip#mysql-8-support)  
+    For MySQL 8 Support, more info is available on the [openmrs-eip](https://github.com/openmrs/openmrs-eip#mysql-8-support) repository.
 
 2. #### Debezium user account
 

--- a/api/src/test/java/org/openmrs/eip/dbsync/BaseDbDrivenTest.java
+++ b/api/src/test/java/org/openmrs/eip/dbsync/BaseDbDrivenTest.java
@@ -35,7 +35,7 @@ import org.testcontainers.lifecycle.Startables;
         ResetMocksTestExecutionListener.class, DeleteDataTestExecutionListener.class, SqlScriptsTestExecutionListener.class,
         TransactionalTestExecutionListener.class })
 @TestPropertySource(properties = "spring.jpa.properties.hibernate.hbm2ddl.auto=update")
-@TestPropertySource(properties = "spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL5Dialect")
+@TestPropertySource(properties = "spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL55Dialect")
 @TestPropertySource(properties = "camel.springboot.routes-collector-enabled=false")
 @TestPropertySource(properties = "spring.liquibase.enabled=false")
 public abstract class BaseDbDrivenTest {

--- a/api/src/test/java/org/openmrs/eip/dbsync/BaseDbDrivenTest.java
+++ b/api/src/test/java/org/openmrs/eip/dbsync/BaseDbDrivenTest.java
@@ -35,7 +35,7 @@ import org.testcontainers.lifecycle.Startables;
         ResetMocksTestExecutionListener.class, DeleteDataTestExecutionListener.class, SqlScriptsTestExecutionListener.class,
         TransactionalTestExecutionListener.class })
 @TestPropertySource(properties = "spring.jpa.properties.hibernate.hbm2ddl.auto=update")
-@TestPropertySource(properties = "spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL55Dialect")
+@TestPropertySource(properties = "spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL5Dialect")
 @TestPropertySource(properties = "camel.springboot.routes-collector-enabled=false")
 @TestPropertySource(properties = "spring.liquibase.enabled=false")
 public abstract class BaseDbDrivenTest {

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <javaCompilerVersion>1.8</javaCompilerVersion>
-        <eipVersion>3.2.0</eipVersion>
+        <eipVersion>3.1.1-SNAPSHOT</eipVersion>
         <sprintBootVersion>2.3.0.RELEASE</sprintBootVersion>
         <camelVersion>3.3.0</camelVersion>
         <jsonassert.version>1.5.0</jsonassert.version>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <javaCompilerVersion>1.8</javaCompilerVersion>
-        <eipVersion>3.1.1-SNAPSHOT</eipVersion>
+        <eipVersion>3.2.0</eipVersion>
         <sprintBootVersion>2.3.0.RELEASE</sprintBootVersion>
         <camelVersion>3.3.0</camelVersion>
         <jsonassert.version>1.5.0</jsonassert.version>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <javaCompilerVersion>1.8</javaCompilerVersion>
-        <eipVersion>3.1.0</eipVersion>
+        <eipVersion>3.2.0</eipVersion>
         <sprintBootVersion>2.3.0.RELEASE</sprintBootVersion>
         <camelVersion>3.3.0</camelVersion>
         <jsonassert.version>1.5.0</jsonassert.version>

--- a/receiver-app/configuration/application.properties
+++ b/receiver-app/configuration/application.properties
@@ -112,6 +112,8 @@ openmrs.db.name=
 spring.openmrs-datasource.driverClassName=com.mysql.jdbc.Driver
 
 # Url of the openMRS datasource, you don't have to change this value as long you've set the placeholder property values
+# For compatibility with MySQL 8, append the allowPublicKeyRetrieval=true parameter to the URL. For example;
+# spring.openmrs-datasource.jdbcUrl=jdbc:mysql://${openmrs.db.host}:${openmrs.db.port}/${openmrs.db.name}?allowPublicKeyRetrieval=true
 spring.openmrs-datasource.jdbcUrl=jdbc:mysql://${openmrs.db.host}:${openmrs.db.port}/${openmrs.db.name}
 
 # User name of the openMRS datasource
@@ -131,6 +133,8 @@ spring.mngt-datasource.driverClassName=
 spring.mngt-datasource.dialect=
 
 # Url of the management datasource
+# When using MySQL 8 for the management database, append the allowPublicKeyRetrieval=true parameter to the URL. For example;
+# spring.mngt-datasource.jdbcUrl=jdbc:mysql://mysqlUrl:3306/my-database?allowPublicKeyRetrieval=true
 spring.mngt-datasource.jdbcUrl=
 
 # User name of the management datasource

--- a/sender-app/configuration/application.properties
+++ b/sender-app/configuration/application.properties
@@ -89,6 +89,8 @@ openmrs.db.name=
 spring.openmrs-datasource.driverClassName=com.mysql.jdbc.Driver
 
 # Url of the openMRS datasource, you don't have to change this value as long you've set the placeholder property values
+# For compatibility with MySQL 8, append the allowPublicKeyRetrieval=true parameter to the URL. For example;
+# spring.openmrs-datasource.jdbcUrl=jdbc:mysql://${openmrs.db.host}:${openmrs.db.port}/${openmrs.db.name}?allowPublicKeyRetrieval=true
 spring.openmrs-datasource.jdbcUrl=jdbc:mysql://${openmrs.db.host}:${openmrs.db.port}/${openmrs.db.name}
 
 # User name of the openMRS datasource
@@ -108,6 +110,8 @@ spring.mngt-datasource.driverClassName=
 spring.mngt-datasource.dialect=
 
 # Url of the management datasource
+# When using MySQL 8 for the management database, append the allowPublicKeyRetrieval=true parameter to the URL. For example;
+# spring.mngt-datasource.jdbcUrl=jdbc:mysql://mysqlUrl:3306/my-database?allowPublicKeyRetrieval=true
 spring.mngt-datasource.jdbcUrl=
 
 # User name of the management datasource
@@ -132,6 +136,12 @@ debezium.db.serverId=
 # Unique logical name of the MySQL database server, maps to the debezium MySQL connector property named
 # database.server.name, DO NOT change after setting it
 debezium.db.serverName=
+
+
+# For a detailed explanation of usable Debezium Connector Component options/parameters including the one used in this example, please refer to https://camel.apache.org/components/3.20.x/debezium-mysql-component.html#_endpoint_query_option_additionalProperties
+# To add an extra parameter allowPublicKeyRetrieval required by mysql 8, additionalProperties.database option documented in the above link will be used.
+# debezium.extraParameters will be appended to the overall Debezium Connector component URL. Additionally, Debezium Connector Component options/parameters should be prefixed by & symbol. For example;
+# debezium.extraParameters=&additionalProperties.database.allowPublicKeyRetrieval=true
 
 # Database username for debezium user account you created to access the MySQL binlog, maps to the debezium MySQL
 # connector property named database.user, it's highly recommended to create separate user account as described at


### PR DESCRIPTION
[EIP-129](https://issues.openmrs.org/browse/EIP-129): Add support for MySQL 8 for DbSync